### PR TITLE
BREAKING: Adjust neos dependency constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "Neos package that helps implementing responsive images based on npm's lazyimages",
     "license": "MIT",
     "require": {
-        "neos/fusion": "~3.0 || ~4.0 || dev-master"
+        "neos/fusion": "~3.3 || ~4.0 || ~5.0 || dev-master"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Set compatibility from neos 3.3 (last maintained version) up to version 5